### PR TITLE
Fixed TypeError: password_hash() expects parameter 3 to be array, null given

### DIFF
--- a/src/PasswordHasher.php
+++ b/src/PasswordHasher.php
@@ -26,11 +26,10 @@ class PasswordHasher
         $this->algorithm = $algorithm;
 
         if ($parameters === null) {
-            $parameters = self::SAFE_PARAMETERS[$algorithm] ?? null;
+            $parameters = self::SAFE_PARAMETERS[$algorithm] ?? [];
         }
         $this->parameters = $parameters;
     }
-
 
     /**
      * Generates a secure hash from a password and a random salt.

--- a/tests/PasswordHasherTest.php
+++ b/tests/PasswordHasherTest.php
@@ -7,6 +7,17 @@ use Yiisoft\Security\PasswordHasher;
 
 class PasswordHasherTest extends TestCase
 {
+    public function testPasswordHashWithDefaults(): void
+    {
+        $password = new PasswordHasher();
+
+        $secret = 'secret';
+        $hash = $password->hash($secret);
+
+        $this->assertTrue($password->validate($secret, $hash));
+        $this->assertFalse($password->validate('test', $hash));
+    }
+
     public function testPasswordHash(): void
     {
         $password = new PasswordHasher(PASSWORD_BCRYPT, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Fixed `TypeError: password_hash() expects parameter 3 to be array, null given` thrown when  creating `PasswordHasher` with default values

Added test for this case